### PR TITLE
Improve Prereq Display

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "boilerclasses",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "boilerclasses",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@chakra-ui/icons": "^2.1.1",
         "@chakra-ui/next-js": "^2.2.0",

--- a/src/components/prereqs.js
+++ b/src/components/prereqs.js
@@ -5,36 +5,42 @@ const Prereqs = ({ course, scheduler = false }) => {
   const router = useRouter();
 
   const preReqCourseElement = (token, i) => {
-    const [detailId, concurrent] = token.split(' ');
-    const subjectCodeMatch = token.match(/[A-Z]+/);
-    const courseNumberMatch = token.match(/\d+/);
+    if(token.split(' ').length === 2) {
+      const [detailId, concurrent] = token.split(' ');
+      const subjectCodeMatch = token.match(/[A-Z]+/);
+      const courseNumberMatch = token.match(/\d+/);
 
-    //TODO: determine if this should be handled somehow
-    // if (!subjectCodeMatch || !courseNumberMatch) {
-    //   return null;
-    // }
+      if (!subjectCodeMatch || !courseNumberMatch) {
+        return <li><p>Prereq Error! Check Purdue's official prereq report</p></li>;
+      }
 
-    const subjectCode = subjectCodeMatch[0];
-    const courseNumber = courseNumberMatch[0];
+      const subjectCode = subjectCodeMatch[0];
+      const courseNumber = courseNumberMatch[0];
 
-    return <li className='' key={i}>
-      <a
-        onClick={(e) => {
-          if (scheduler) {
-            window.open(`https://www.boilerclasses.com/detail/${detailId}`, '_blank');
-          } else {
-            router.push(`/detail/${detailId}`);
-          }
-        }}
-        className='underline decoration-dotted cursor-pointer hover:text-blue-700 transition-all duration-300 ease-out text-blue-600'
-      >
-        {subjectCode} {courseNumber}
-      </a>
-      {concurrent === "True" ? " [may be taken concurrently]" : ""}
-    </li>
+      return <li className='' key={i}>
+        <a
+          onClick={(e) => {
+            if (scheduler) {
+              window.open(`https://www.boilerclasses.com/detail/${detailId}`, '_blank');
+            } else {
+              router.push(`/detail/${detailId}`);
+            }
+          }}
+          className='underline decoration-dotted cursor-pointer hover:text-blue-700 transition-all duration-300 ease-out text-blue-600'
+        >
+          {subjectCode} {courseNumber}
+        </a>
+        {concurrent === "True" ? " [may be taken concurrently]" : ""}
+      </li>
+    } else if (token.split(' ').length == 3) {
+      const [subject, number, concurrent] = token.split(' ');
+      return `${subject} ${number}${concurrent === "True" ? " [may be taken concurrently]" : ""}`;
+    } else {
+      return `${"()".includes(token) ? "" : " "}${token}${"()".includes(token) ? "" : " "}`;
+    }
   }
 
-  const parsePrereqsNew = (prereqs) => {
+  const parsePrereqs = (prereqs) => {
     const tokenize = (tokens) => {
 
       const stack = [];
@@ -93,8 +99,6 @@ const Prereqs = ({ course, scheduler = false }) => {
       );
     };
 
-    console.log(prereqs)
-
     const [tree] = tokenize(prereqs);
 
     return (
@@ -110,7 +114,7 @@ const Prereqs = ({ course, scheduler = false }) => {
         <div className="prerequisites-container">
           {!scheduler && <div className="text-tertiary lg:text-sm text-xs mb-2">Prerequisites:</div>}
           <div className="lg:text-sm text-xs text-tertiary font-medium">
-            {parsePrereqsNew(course.prereqs)}
+            {parsePrereqs(course.prereqs)}
           </div>
         </div>
       )

--- a/src/components/prereqs.js
+++ b/src/components/prereqs.js
@@ -4,7 +4,7 @@ import Link from 'next/link';
 const Prereqs = ({ course, scheduler = false }) => {
   const router = useRouter();
 
-  const preReqCourseElement = (token, i) => {
+  const prereqCourseElement = (token, i) => {
     if (token.split(' ').length === 2) {
       const [detailId, concurrent] = token.split(' ');
       const subjectCodeMatch = token.match(/[A-Z]+/);
@@ -34,7 +34,6 @@ const Prereqs = ({ course, scheduler = false }) => {
       </li>
     } else if (token.split(' ').length == 3) {
       const [subject, number, concurrent] = token.split(' ');
-      console.log(token + " :::: " + subject + " " + number + " " + concurrent);
       return <li className='' key={i}>
         {subject} {number}{concurrent === "True" ? " [may be taken concurrently]" : ""}
       </li>
@@ -66,7 +65,7 @@ const Prereqs = ({ course, scheduler = false }) => {
         currentOp = token;
         i++;
       } else {
-        stack.push({ type: "course", value: preReqCourseElement(token, i) });
+        stack.push({ type: "course", value: prereqCourseElement(token, i) });
         i++;
       }
     }

--- a/src/components/prereqs.js
+++ b/src/components/prereqs.js
@@ -5,7 +5,7 @@ const Prereqs = ({ course, scheduler = false }) => {
   const router = useRouter();
 
   const preReqCourseElement = (token, i) => {
-    if(token.split(' ').length === 2) {
+    if (token.split(' ').length === 2) {
       const [detailId, concurrent] = token.split(' ');
       const subjectCodeMatch = token.match(/[A-Z]+/);
       const courseNumberMatch = token.match(/\d+/);
@@ -34,7 +34,10 @@ const Prereqs = ({ course, scheduler = false }) => {
       </li>
     } else if (token.split(' ').length == 3) {
       const [subject, number, concurrent] = token.split(' ');
-      return `${subject} ${number}${concurrent === "True" ? " [may be taken concurrently]" : ""}`;
+      console.log(token + " :::: " + subject + " " + number + " " + concurrent);
+      return <li className='' key={i}>
+        {subject} {number}{concurrent === "True" ? " [may be taken concurrently]" : ""}
+      </li>
     } else {
       return `${"()".includes(token) ? "" : " "}${token}${"()".includes(token) ? "" : " "}`;
     }
@@ -53,7 +56,7 @@ const Prereqs = ({ course, scheduler = false }) => {
 
         const [group, consumed] = generatePrereqTree(tokens.slice(i + 1));
         stack.push(group);
-        
+
         //Add an offset to remove all the tokens that were consumed in that sublevel
         i += consumed + 2;
 
@@ -80,18 +83,18 @@ const Prereqs = ({ course, scheduler = false }) => {
     ];
   };
 
-  const renderNode = (node) => {
+  const renderNode = (node, i) => {
     // HTML elements were saved directly to the tree for courses
     if (node.type === "course") {
       return node.value;
     }
 
     return (
-      <li>
+      <li key={i + "-" + node.op + node.children.map(child => child.value?.key || child.value).join("")}>
         {node.op === "and" ? (node.children.length > 2 ? "ALL of:" : "BOTH of:") : "ONE of:"}
         <ul style={{ paddingLeft: "1em" }}>
           {node.children.map((child, i) => (
-            renderNode(child)
+            renderNode(child, i)
           ))}
         </ul>
       </li>
@@ -99,12 +102,12 @@ const Prereqs = ({ course, scheduler = false }) => {
   };
 
   const parsePrereqs = (prereqs) => {
-    
+
     const [tree] = generatePrereqTree(prereqs);
 
     return (
       <div>
-        <ul>{renderNode(tree)}</ul>
+        <ul>{renderNode(tree, 0)}</ul>
       </div>
     );
   };
@@ -113,7 +116,11 @@ const Prereqs = ({ course, scheduler = false }) => {
     return (
       (course.prereqs && course.prereqs.length > 0 && course.prereqs[0].split(' ')[0] !== router.query.id) && (
         <div className="prerequisites-container">
-          {!scheduler && <div className="text-tertiary lg:text-sm text-xs mb-2">Prerequisites:</div>}
+          {!scheduler && (
+            <div className="font-semibold lg:text-sm text-xs text-tertiary border-b border-[rgb(var(--background-secondary-color))] mb-2">
+              Prerequisites
+            </div>
+          )}
           <div className="lg:text-sm text-xs text-tertiary font-medium">
             {parsePrereqs(course.prereqs)}
           </div>

--- a/src/pages/detail/[id].js
+++ b/src/pages/detail/[id].js
@@ -81,7 +81,7 @@ const CardDetails = ({ courseData, semData }) => {
             <CourseLinks />
             <CourseDescription />
             {/* Prerequisites */}
-            <div className='mb-4'>
+            <div className='my-4'>
               <Prereqs course={courseData} />
             </div>
           </div>


### PR DESCRIPTION
This improves the prerequisite display by parsing them as a tree that makes the requirements less confusing. The tree now displays things like "ALL of:", "BOTH of:", and "ONE of:", which makes them much easier to parse as a human. The prereq courses themselves are still displayed in exactly the same way (i.e., links are included the same way for courses that have them). Let me know what you think of it!